### PR TITLE
Update to version 0.8.0

### DIFF
--- a/com.beakerbrowser.Beaker.appdata.xml
+++ b/com.beakerbrowser.Beaker.appdata.xml
@@ -17,7 +17,7 @@
   </screenshots>
   <url type="homepage">https://beakerbrowser.com</url>
   <releases>
-    <release version="0.8.0-prerelease.9" date="2018-09-08"/>
+    <release version="0.8.0" date="2018-10-22"/>
   </releases>
   <content_rating type="oars-1.0">
     <content_attribute id="violence-cartoon">none</content_attribute>

--- a/com.beakerbrowser.Beaker.yml
+++ b/com.beakerbrowser.Beaker.yml
@@ -25,8 +25,8 @@ modules:
   - type: file
     only-arches:
     - x86_64
-    url: https://github.com/beakerbrowser/beaker/releases/download/0.8.0-prerelease.9/beaker-browser-0.8.0-prerelease.9-x86_64.AppImage
-    sha256: 54583ff6104048009045fd21f707509dba49ae234837e66e7a9a567877b2468e
+    url: https://github.com/beakerbrowser/beaker/releases/download/0.8.0/beaker-browser-0.8.0-x86_64.AppImage
+    sha256: c0c76dc58f19f47b5764a2fab04dad695297107bd359193b2adf5df3723fbadf
   - type: script
     dest-filename: beaker
     commands:
@@ -37,8 +37,8 @@ modules:
   - type: file
     path: com.beakerbrowser.Beaker.desktop
   build-commands:
-  - chmod +x beaker-browser-0.8.0-prerelease.9-x86_64.AppImage
-  - ./beaker-browser-0.8.0-prerelease.9-x86_64.AppImage --appimage-extract
+  - chmod +x beaker-browser-0.8.0-x86_64.AppImage
+  - ./beaker-browser-0.8.0-x86_64.AppImage --appimage-extract
 
   - mkdir /app/beaker
   - cp -r squashfs-root/app/* /app/beaker/


### PR DESCRIPTION
This version was released an hour ago.
https://github.com/beakerbrowser/beaker/releases/tag/0.8.0

I believe this is all that’s required, but should undergo more testing.